### PR TITLE
add interstitial is ready binding interface

### DIFF
--- a/MoPubBinding.m
+++ b/MoPubBinding.m
@@ -67,6 +67,10 @@ void _moPubShowInterstitialAd( const char * adUnitId )
 	[[MoPubManager sharedManager] showInterstitialAd:GetStringParam( adUnitId )];
 }
 
+bool _moPubIsInterstitialReady( const char * adUnitId )
+{
+    return [[MoPubManager sharedManager] isInterstitialReady:GetStringParam( adUnitId )];
+}
 
 // Reports an app download to MoPub
 void _moPubReportApplicationOpen( const char * iTunesAppId )

--- a/MoPubManager.h
+++ b/MoPubManager.h
@@ -64,6 +64,6 @@ typedef enum
 
 - (void)showInterstitialAd:(NSString*)adUnitId;
 
-
+- (BOOL)isInterstitialReady:(NSString*)adUnitId;
 
 @end

--- a/MoPubManager.mm
+++ b/MoPubManager.mm
@@ -251,6 +251,13 @@ UIViewController *UnityGetGLViewController();
 	[interstitial showFromViewController:UnityGetGLViewController()];
 }
 
+- (BOOL)isInterstitialReady:(NSString*)adUnitId
+{
+    MPInterstitialAdController *interstitial = [MPInterstitialAdController interstitialAdControllerForAdUnitId:adUnitId];
+    
+    return interstitial.ready;
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - MPAdViewDelegate


### PR DESCRIPTION
I'm adding a function isInterstitialReady in the unity ios mopub binding. I believe this function will be useful to check if the interstitial ads is ready.

Thank you